### PR TITLE
add configurability to the catalog textures

### DIFF
--- a/astro3d/data/astro3d.cfg
+++ b/astro3d/data/astro3d.cfg
@@ -79,10 +79,10 @@ lines = ['bulge', 'disk', 'filament']
 
 [catalog_textures]
 central_star = {
-             'model': StarTexture,
-             'color': '#9900cc',
-             'radius_a': 10,
-             'radius_b': 5,
-             'depth': 5,
-             'slope': 1.0
+	'model': InvertStarTexture,
+	'color': '#9900cc',
+	'radius_a': 10,
+	'radius_b': 5,
+	'depth': 5,
+	'slope': 1.0
 	}

--- a/astro3d/gui/textures.py
+++ b/astro3d/gui/textures.py
@@ -2,12 +2,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from ..core.textures import (
-    DotsTexture,
-    LinesTexture,
-    HexagonalGrid,
-    StarTexture
-)
+from ..core.textures import *
 
 __all__ = ['TextureConfig']
 


### PR DESCRIPTION
Resolves #22 

Also adds the `InvertStarTexture` as a prototype for a "dome"-like structure.