### PR TITLE
Fix inverted star texture

### DIFF
--- a/astro3d/core/textures.py
+++ b/astro3d/core/textures.py
@@ -15,7 +15,7 @@ __doctest_skip__ = ['LinesTexture', 'DotsTexture']
 __all__ = [
     'DotsTexture',
     'HexagonalGrid',
-    'InvertStarTexture',
+    'InvertedStarTexture',
     'LinesTexture',
     'StarClusterTexture',
     'StarTexture',
@@ -466,7 +466,7 @@ class StarTexture(Fittable2DModel):
         return model
 
 
-class InvertStarTexture(Fittable2DModel):
+class InvertedStarTexture(Fittable2DModel):
     """
     An inverted 2D star texture model.
 


### PR DESCRIPTION
The new texture is called `InvertedStarTexture` (note the slight name change).  The cross section looks like this:

![star_textures](https://user-images.githubusercontent.com/4992897/39780335-fe3f6e9c-52d9-11e8-83be-3bd5ed420ab1.png)

The `InvertedStarTexture` has the same parameters as `StarTexture` except it has `height` (height of dome) instead of `depth`.